### PR TITLE
Artifact refactoring, key value, and unit tests

### DIFF
--- a/flowz/artifacts.py
+++ b/flowz/artifacts.py
@@ -301,9 +301,24 @@ class KeyedArtifact(WrappedArtifact):
         return iter((self.key, self))
 
     def transform(self, func, *params, **kw):
+        """
+        Create a KeyedArtifact that transforms the value of this artifact, but preserves
+        the same key.
+
+        @param func: a synchronous function
+        @param params: the initial parameter to func, to which this artifacts value will be appended
+        """
         params += (self.value,)
         return KeyedArtifact(self.key, DerivedArtifact(func, *params, **kw))
 
     def threaded_transform(self, executor, func, *params, **kw):
+        """
+        Create a KeyedArtifact that transforms the value of this artifact, but preserves
+        the same key.  The transformation will run on a separate thread.
+
+        @param executor: the thread pool executor
+        @param func: a synchronous function
+        @param params: the initial parameter to func, to which this artifacts value will be appended
+        """
         params += (self.value,)
         return KeyedArtifact(self.key, ThreadedDerivedArtifact(executor, func, *params, **kw))

--- a/flowz/artifacts.py
+++ b/flowz/artifacts.py
@@ -30,17 +30,14 @@ class AbstractArtifact(object):
             self._as_string = '%s<%s>' % (type(self).__name__, name)
             self.name = name
 
-
     def __str__(self):
         return self._as_string
-
 
     def exists(self):
         """
         Returns True if the artifact already exists; False otherwise.
         """
         return self.__exists__
-
 
     def ensure(self):
         """
@@ -51,7 +48,6 @@ class AbstractArtifact(object):
             self.__ensure__ = self.__start_ensure__()
         return self.__ensure__
 
-
     @gen.coroutine
     def __start_ensure__(self):
         """
@@ -59,7 +55,6 @@ class AbstractArtifact(object):
         """
         yield self.get()
         raise gen.Return(True)
-
 
     def get(self):
         """
@@ -70,12 +65,10 @@ class AbstractArtifact(object):
             self.__get__ = self.__start_get__()
         return self.__get__
 
-
     @gen.coroutine
     def __start_get__(self):
         self.__exists__ = True
         raise gen.Return(self)
-
 
     def as_channel(self):
         """
@@ -83,13 +76,11 @@ class AbstractArtifact(object):
         """
         return channels.IterChannel(a for a in (self,))
 
-
     def value_channel(self):
         """
         Returns a channel with self's artifact when it's ready.
         """
         return self.as_channel().map(lambda a: a.get()).each_ready()
-
 
     def ensure_channel(self):
         """
@@ -109,12 +100,10 @@ class ExtantArtifact(AbstractArtifact):
         super(ExtantArtifact, self).__init__(logger=logger, name=name)
         self.getter = getter
 
-
     @gen.coroutine
     def __start_ensure__(self):
         # It is known to exist, so there's nothing to ensure.
         raise gen.Return(True)
-
 
     @gen.coroutine
     def __start_get__(self):
@@ -133,7 +122,6 @@ class TransformArtifact(AbstractArtifact):
                 kw.get('logger'), kw.get('name'))
         self.sources = sources
         self.transform = transform
-
 
     @gen.coroutine
     def __start_get__(self):
@@ -163,7 +151,6 @@ class ThreadedTransformArtifact(AbstractArtifact):
         self.transform = transform
         self.executor = executor
 
-
     @concurrent.run_on_executor
     def __transform__(self, *sources):
         try:
@@ -171,7 +158,6 @@ class ThreadedTransformArtifact(AbstractArtifact):
         except:
             self.logger.exception("Transformation failure.")
             raise
-
 
     @gen.coroutine
     def __start_get__(self):
@@ -188,14 +174,11 @@ class PassthruTransformArtifact(AbstractArtifact):
         self.original = original
         self.transformer = transformer
 
-
     def exists(self):
         return self.original.exists()
 
-
     def __getattr__(self, attr):
         return getattr(self.original, attr)
-
 
     def __getitem__(self, item):
         try:
@@ -204,10 +187,8 @@ class PassthruTransformArtifact(AbstractArtifact):
             # Want the KeyError to originate here.
             raise KeyError("No such key: %s" % repr(item))
 
-
     def ensure(self):
         return self.original.ensure()
-
 
     @gen.coroutine
     def __start_get__(self):

--- a/flowz/test/artifacts/artifacts_test.py
+++ b/flowz/test/artifacts/artifacts_test.py
@@ -1,0 +1,295 @@
+from collections import OrderedDict
+from concurrent import futures
+
+from nose import tools
+from tornado import gen
+from tornado import testing as tt
+import tornado.concurrent
+
+from flowz.artifacts import (ExtantArtifact, DerivedArtifact, ThreadedDerivedArtifact,
+                             WrappedArtifact, TransformedArtifact, KeyedArtifact,
+                             maybe_artifact)
+from flowz.channels import ChannelDone
+
+
+class ArtifactsTest(tt.AsyncTestCase):
+    NUM_ARR = [1, 2, 3, 4, 5]
+    NUM_DICT = {1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}
+    NUM_ORDERED_DICT = OrderedDict([(i, NUM_DICT[i]) for i in NUM_ARR])
+    NUM_REVERSED_DICT = OrderedDict([(i, NUM_DICT[i]) for i in reversed(NUM_ARR)])
+
+    @tt.gen_test
+    def test_extant_artifact(self):
+        @gen.coroutine
+        def getter():
+            raise gen.Return(self.NUM_ORDERED_DICT)
+
+        artifact = ExtantArtifact(getter, name="ExtantArtifactTester")
+
+        tools.assert_true("ExtantArtifactTester" in str(artifact))
+        tools.assert_true(artifact.exists())
+        tools.assert_true(artifact.ensure())
+
+        value = yield artifact.get()
+
+        tools.assert_equal(value, self.NUM_ORDERED_DICT)
+
+    @tt.gen_test
+    def test_derived_artifact(self):
+        def deriver(num_arr, num_dict):
+            return OrderedDict([(i, num_dict[i]) for i in num_arr])
+
+        artifact = DerivedArtifact(deriver, self.NUM_ARR, self.NUM_DICT)
+
+        tools.assert_false(artifact.exists())
+
+        value = yield artifact.get()
+
+        tools.assert_equal(value, self.NUM_ORDERED_DICT)
+        tools.assert_true(artifact.exists())
+        tools.assert_true(artifact.ensure())
+
+        # Now call with a slightly different order, calling ensure() before get()
+        artifact = DerivedArtifact(deriver, self.NUM_ARR, self.NUM_DICT)
+
+        tools.assert_false(artifact.exists())
+        ensured = yield artifact.ensure()
+        tools.assert_true(ensured)
+
+        value = yield artifact.get()
+
+        tools.assert_equal(value, self.NUM_ORDERED_DICT)
+        tools.assert_true(artifact.exists())
+
+    @tt.gen_test
+    def test_threaded_derived_artifact(self):
+        def deriver(num_arr, num_dict):
+            return OrderedDict([(i, num_dict[i]) for i in num_arr])
+
+        executor = futures.ThreadPoolExecutor(1)
+
+        artifact = ThreadedDerivedArtifact(executor, deriver, self.NUM_ARR, self.NUM_DICT)
+
+        tools.assert_false(artifact.exists())
+
+        value = yield artifact.get()
+
+        tools.assert_equal(value, self.NUM_ORDERED_DICT)
+        tools.assert_true(artifact.exists())
+        tools.assert_true(artifact.ensure())
+
+        # Now call with a slightly different order, calling ensure() before get()
+        artifact = ThreadedDerivedArtifact(executor, deriver, self.NUM_ARR, self.NUM_DICT)
+
+        tools.assert_false(artifact.exists())
+        ensured = yield artifact.ensure()
+        tools.assert_true(ensured)
+
+        value = yield artifact.get()
+
+        tools.assert_equal(value, self.NUM_ORDERED_DICT)
+        tools.assert_true(artifact.exists())
+
+    @tt.gen_test
+    def test_wrapped_artifact(self):
+        def deriver(num_arr, num_dict):
+            return OrderedDict([(i, num_dict[i]) for i in num_arr])
+
+        artifact = WrappedArtifact(DerivedArtifact(deriver, self.NUM_ARR, self.NUM_DICT))
+
+        tools.assert_false(artifact.exists())
+        value = yield artifact.get()
+        tools.assert_equal(value, self.NUM_ORDERED_DICT)
+        tools.assert_true(artifact.exists())
+        tools.assert_true(artifact.ensure())
+
+    @tt.gen_test
+    def test_transformed_artifact(self):
+        @gen.coroutine
+        def getter():
+            raise gen.Return(self.NUM_ORDERED_DICT)
+
+        def deriver(num_arr, num_dict):
+            return OrderedDict([(i, num_dict[i]) for i in num_arr])
+
+        def transformer(orig_dict):
+            return OrderedDict([(i, orig_dict[i]) for i in reversed(orig_dict.keys())])
+
+        # Try with an ExtantArtifact
+        artifact = TransformedArtifact(ExtantArtifact(getter), transformer)
+
+        tools.assert_true(artifact.exists())
+        tools.assert_true(artifact.ensure())
+
+        value = yield artifact.get()
+
+        tools.assert_equal(value, self.NUM_REVERSED_DICT)
+
+        # Try with a DerivedArtifact
+        artifact = TransformedArtifact(DerivedArtifact(deriver, self.NUM_ARR, self.NUM_DICT),
+                                       transformer)
+
+        tools.assert_false(artifact.exists())
+
+        value = yield artifact.get()
+
+        tools.assert_equal(value, self.NUM_REVERSED_DICT)
+        tools.assert_true(artifact.exists())
+        tools.assert_true(artifact.ensure())
+
+    @tt.gen_test
+    def test_keyed_artifact(self):
+        def deriver(key, num_dict):
+            return num_dict[key]
+
+        key = 1
+        artifact = KeyedArtifact(key, DerivedArtifact(deriver, key, self.NUM_DICT))
+
+        tools.assert_equal(artifact[0], key)
+        tools.assert_equal(artifact[1], artifact)
+        tools.assert_equal(artifact['key'], key)
+        tools.assert_raises(KeyError, artifact.__getitem__, 'spaz')
+
+        for (a,b) in zip((key, artifact), iter(artifact)):
+            tools.assert_equal(a, b)
+
+        tools.assert_false(artifact.exists())
+
+        value = yield artifact.get()
+
+        tools.assert_equal(value, 'one')
+        tools.assert_true(artifact.exists())
+        tools.assert_true(artifact.ensure())
+
+    @tt.gen_test
+    def test_keyed_artifact_transform(self):
+        def deriver(key, num_dict):
+            return num_dict[key]
+
+        def rderiver(num_dict, val):
+            for (k, v) in num_dict.iteritems():
+                if v == val:
+                    return k
+            return None
+
+        key = 1
+        artifact = KeyedArtifact(key, DerivedArtifact(deriver, key, self.NUM_DICT))
+        artifact2 = artifact.transform(rderiver, self.NUM_DICT)
+
+        key2 = yield artifact2.get()
+        tools.assert_equal(key, key2)
+
+    @tt.gen_test
+    def test_keyed_artifact_threaded_transform(self):
+        def deriver(key, num_dict):
+            return num_dict[key]
+
+        def rderiver(num_dict, val):
+            for (k, v) in num_dict.iteritems():
+                if v == val:
+                    return k
+            return None
+
+        executor = futures.ThreadPoolExecutor(1)
+
+        key = 1
+        artifact = KeyedArtifact(key, DerivedArtifact(deriver, key, self.NUM_DICT))
+        artifact2 = artifact.threaded_transform(executor, rderiver, self.NUM_DICT)
+
+        key2 = yield artifact2.get()
+        tools.assert_equal(key, key2)
+
+    @tt.gen_test
+    def test_maybe_artifact(self):
+        def deriver(key, num_dict):
+            return num_dict[key]
+
+        # prove that both artifacts and non-artifacts result in futures
+        key = 1
+        artifact = DerivedArtifact(deriver, key, self.NUM_DICT)
+        future1 = maybe_artifact(artifact)
+        tools.assert_is_instance(future1, tornado.concurrent.Future)
+
+        future2 = maybe_artifact('one')
+        tools.assert_is_instance(future2, tornado.concurrent.Future)
+
+        val1 = yield future1
+        val2 = yield future2
+        tools.assert_equal(val1, val2)
+
+        # Make sure that just having a "get" function isn't enough to be an artifact!
+        dict_ = {1: 'one'}
+        tools.assert_true(hasattr(dict_, 'get'))
+        future3 = maybe_artifact(dict_)
+        val3 = yield future3
+        tools.assert_equal(val3, dict_)
+
+    # ****** End with helper methods on AbstractArtifact ******
+
+    @tt.gen_test
+    def test_as_channel(self):
+        @gen.coroutine
+        def getter():
+            raise gen.Return('foo')
+
+        artifact = ExtantArtifact(getter)
+        channel = artifact.as_channel()
+        result = yield channel.start()
+        tools.assert_true(result)
+
+        artifact2 = yield channel.next()
+        tools.assert_equal(artifact, artifact2)
+
+        val = yield artifact2.get()
+        tools.assert_equal(val, 'foo')
+
+        try:
+            artifact3 = yield channel.next()
+            tools.assert_true(False, "Channel unexpectedly had an extra artifact")
+        except ChannelDone:
+            pass
+        tools.assert_true(channel.done())
+
+    @tt.gen_test
+    def test_value_channel(self):
+        @gen.coroutine
+        def getter():
+            raise gen.Return('foo')
+
+        artifact = ExtantArtifact(getter)
+        channel = artifact.value_channel()
+        result = yield channel.start()
+        tools.assert_true(result)
+
+        val = yield channel.next()
+        tools.assert_equal(val, 'foo')
+
+        try:
+            val2 = yield channel.next()
+            tools.assert_true(False, "Channel unexpectedly had an extra value")
+        except ChannelDone:
+            pass
+        tools.assert_true(channel.done())
+
+    @tt.gen_test
+    def test_ensure_channel(self):
+        def deriver():
+            return 'foo'
+
+        artifact = DerivedArtifact(deriver)
+        tools.assert_false(artifact.exists())
+        channel = artifact.ensure_channel()
+        result = yield channel.start()
+        tools.assert_true(result)
+
+        ensured = yield channel.next()
+        tools.assert_true(ensured)
+
+        tools.assert_true(artifact.exists())
+
+        try:
+            ensured2 = yield channel.next()
+            tools.assert_true(False, "Channel unexpectedly had an extra value")
+        except ChannelDone:
+            pass
+        tools.assert_true(channel.done())

--- a/flowz/test/channels/iteration_test.py
+++ b/flowz/test/channels/iteration_test.py
@@ -1,5 +1,4 @@
 import datetime
-import itertools
 
 import mock
 from nose import tools
@@ -7,15 +6,7 @@ from tornado import gen
 from tornado import testing as tt
 
 from flowz import channels
-
-@gen.coroutine
-def raises_channel_done(channel):
-    try:
-        yield channel.next()
-        raise Exception("ChannelDone not raised!")
-    except channels.ChannelDone:
-        # This just increments the test count,
-        tools.assert_equal(True, True)
+from .util import raises_channel_done
 
 
 @gen.coroutine

--- a/flowz/test/channels/util.py
+++ b/flowz/test/channels/util.py
@@ -1,0 +1,17 @@
+from nose import tools
+from tornado import gen
+
+from flowz import channels
+
+
+@gen.coroutine
+def raises_channel_done(channel):
+    """
+    Tests that a channel has already reached its last item.
+    """
+    try:
+        yield channel.next()
+        raise Exception("ChannelDone not raised!")
+    except channels.ChannelDone:
+        # This just increments the test count,
+        tools.assert_equal(True, True)

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
         ],
     install_requires = [
         'tornado >= 4.2',
+        'futures >= 3.0.5'
         ])
-


### PR DESCRIPTION
- Changed names of most artifacts
- Minor internal changes to existing artifacts
- Split PassthruTransformArtifact into two classes (WrappedArtifact and TransformedArtifact)
- Created KeyedArtifact
- Added unit testing for all the classes
