### PR TITLE
Channel management tools

### DIFF
--- a/flowz/channels/management.py
+++ b/flowz/channels/management.py
@@ -26,3 +26,27 @@ class ChannelAccessor(AbstractChannelAccessor):
         self.channel = self.builder()
         return self.channel
 
+
+class ChannelManager(object):
+    def __init__(self):
+        self.channels = {}
+
+    def add_builder(self, name, buildfunc):
+        bld = ChannelAccessor(buildfunc)
+        return self.add_accessor(name, bld)
+
+    def add_accessor(self, name, accessor):
+        self.channels[name] = accessor
+        return self
+
+    def add_channel(self, name, channel):
+        self.add_builder(name, lambda: channel)
+        return self
+
+    def __getitem__(self, key):
+        try:
+            accessor = self.channels[key]
+            return accessor.get()
+        except KeyError:
+            raise KeyError("No such key %s" % repr(key))
+

--- a/flowz/channels/management.py
+++ b/flowz/channels/management.py
@@ -52,10 +52,10 @@ class ChannelManager(object):
             raise KeyError("No such key %s" % repr(key))
 
 
-def channelproperty(fn):
+def _channelproperty(manager_name, fn):
     @functools.wraps(fn)
     def wrapped(self):
-        manager = self.channel_manager
+        manager = getattr(self, manager_name)
         name = fn.__name__
         try:
             return manager[name]
@@ -63,4 +63,9 @@ def channelproperty(fn):
             manager.add_builder(name, lambda: fn(self))
             return manager[name]
     return property(wrapped)
+
+def channelproperty(fn_or_name):
+    if callable(fn_or_name):
+        return _channelproperty('channel_manager', fn_or_name)
+    return lambda fn: _channelproperty(fn_or_name, fn)
 

--- a/flowz/channels/management.py
+++ b/flowz/channels/management.py
@@ -1,25 +1,73 @@
 import functools
 
 class AbstractChannelAccessor(object):
+    """
+    Wraps the access to a :class:`flowz.channels.core.Channel`.
+
+    Given some logic for how to build a particular channel
+    (:meth:`AbstractChannelAccessor.get_new`),
+    this will manage the lifecycle of the resulting channel:
+    - Build it and return it on first access
+    - Return a new tee of it on each subsequent access.
+
+    The channel is accessed via the :meth:`AbstractChannelAccesor.get` method.
+
+    Details as to why this matters:
+
+    Garbage collection of items on a channel depends on channels being consumed
+    to completion.
+
+    When a `:meth:`flowz.channels.core.Channel.tee` is taken of a channel, both
+    the original channel *and* the tee need to be consumed for items to be
+    freed for GC.
+
+    The creation of extraneous tees, then, can cause memory leaks.
+    """
+
     channel = None
 
     def get(self):
+        """
+        Returns the managed :class:`flowz.channels.core.Channel`.
+
+        Will give the original channel on first access, and a new tee per
+        subsequent access.
+        """
         if self.channel:
             return self.get_existing()
         return self.get_new()
 
 
     def get_existing(self):
+        """
+        For internal/subclass use, the accessor for subsequent access.
+        """
         return self.channel.tee()
 
 
     def get_new(self):
+        """
+        For internal/subclass use, the accessor for building and first access.
+
+        Must be overridden in subclasses to build the
+        :class:`flowz.channels.core.Channel`, set it to `self.channel``, and
+        return it.
+        """
         raise NotImplementedError("get_new() needs to be defined.")
 
 
 
 class ChannelAccessor(AbstractChannelAccessor):
+    """
+    An `AbstractChannelAccessor` implementation with a build function.
+    """
+
     def __init__(self, buildfunc):
+        """
+        The managed channel will be assembled with :func:`buildfunc`.
+
+        So :func:`buildfunc` must return the intended channel to be managed.
+        """
         self.builder = buildfunc
 
 
@@ -29,22 +77,69 @@ class ChannelAccessor(AbstractChannelAccessor):
 
 
 class ChannelManager(object):
+    """
+    A keyed collection for managed channels.
+
+    Allows for the assembly of managed channels organized by key (like a dict),
+    and access to those channels (via key) will properly manage
+    :meth:`flowz.channels.core.Channel.tee` calls as done by
+    :class:`AbstractChannelAccessor`
+    """
+
     def __init__(self):
         self.channels = {}
 
     def add_builder(self, name, buildfunc):
+        """
+        Adds a :class:`ChannelAccessor` under key ``name``.
+
+        Args:
+            name (hashable): the key to use for identifying this managed
+                channel.
+            buildfunc (callable): the channel builder function to use in
+                the underlying :class:`ChannelAccessor`.
+
+        Returns ``self`` (the :class:`ChannelManager`).
+        """
         bld = ChannelAccessor(buildfunc)
         return self.add_accessor(name, bld)
 
     def add_accessor(self, name, accessor):
+        """
+        Adds the :class:`AbstractChannelAccessor` ``accessor`` under ``name``.
+
+        Args:
+            name (hashable): the key to use for identifying this managed
+                channel.
+            accessor (:class:`AbstractChannelAccessor`): the accessor to use
+                for managing access to the underlying channel.
+
+        Returns ``self`` (the :class:`ChannelManager`).
+        """
         self.channels[name] = accessor
         return self
 
     def add_channel(self, name, channel):
+        """
+        Adds ``channel`` for access management via ``name``.
+
+        Args:
+            name (hashable): the key to use for identifying this managed
+                channel.
+            channel (:class:`flowz.channels.core.Channel`): the channel to
+                be access-managed.
+
+        Returns ``self`` (the :class`ChannelManager`).
+        """
         self.add_builder(name, lambda: channel)
         return self
 
     def __getitem__(self, key):
+        """
+        Access the managed channel associated with ``key``.
+
+        Throws a ``KeyError`` if the ``key`` is unknown.
+        """
         try:
             accessor = self.channels[key]
             return accessor.get()
@@ -65,6 +160,94 @@ def _channelproperty(manager_name, fn):
     return property(wrapped)
 
 def channelproperty(fn_or_name):
+    """
+    Decorates a builder method to act as an access-managed channel.
+
+    Expects to decorate a callable for an object that has a
+    :class:`ChannelManager` instance.  The callable should return a
+    channel to be managed.
+
+    The result is a property that fronts access to the corresponding
+    channel via the :class:`ChannelManager`, meaning that first access
+    to the property will cause the build logic to run, returning the
+    underlying channel, while each subsequent access to the property will
+    return a new :meth:`flowz.channels.core.Channel.tee` result.
+
+    By default, the :class:`ChannelManager` instance is expected to be
+    found at the ``channel_manager`` property of the object.  However,
+    this can be overridden; call the decorator with an alternate string
+    name instead of a function, and you'll get a new decorator function
+    bound to that opposite name.
+
+    An example::
+        from __future__ import print_function
+
+        from flowz import app
+        from flowz.channels import core
+        from flowz.channels import management as mgmt
+
+        class StupidExample(object):
+            def __init__(self, count):
+                self.channel_manager = mgmt.ChannelManager()
+                self.count = count
+
+
+            # We get a channel of numbers from 0 to count.
+            @mgmt.channelproperty
+            def numbers(self):
+                return core.IterChannel(range(self.count))
+
+            # Whereas this is the doubling of those numbers.
+            @mgmt.channelproperty
+            def doubles(self):
+                # self.numbers might be the raw IterChannel, or
+                # it might be a tee thereof, depending on what
+                # has happened first.
+                return self.numbers.map(lambda i: i*2)
+
+            # This pairs them up.  It is guaranteed that there
+            # will be at least one tee of self.numbers, because
+            # it is accessed twice (once directly, once via doubles)
+            @mgmt.channelproperty
+            def pairs(self):
+                return self.numbers.zip(self.doubles)
+
+        # This will print
+        # (0, 0)
+        # (1, 2)
+        # (2, 4)
+        # (3, 6)
+        # (4, 8)
+        app.Flo([StupidExample(5).pairs.map(print)]).run()
+
+    If you wanted to name your :class:`ChannelManager` something else,
+    this would do it::
+        class OtherExample(object):
+            def __init__(self, count):
+                self.mgr = mgmt.ChannelManager()
+                self.count = count
+
+            @mgmt.channelproperty('mgr')
+            def numbers(self):
+                return core.IterChannel(range(self.count))
+
+            @mgmt.channelproperty('mgr')
+            def doubles(self):
+                return self.numbers.map(lambda i: i*2)
+
+            @mgmt.channelproperty('mgr')
+            def pairs(self):
+                return self.numbers.zip(self.doubles)
+
+    Args:
+        fn_or_name (callable or string): if a callable, the callable to
+            be used as the underlying ``buildfunc`` for the managed channel
+            associated with this property.  Otherwise, the name of attribute
+            at which the :class:`ChannelManager` would be found.
+
+    Returns a new property if `fn_or_name` was a callable, and a new decorator
+    function bound to the alternate attribute name otherwise.
+    """
     if callable(fn_or_name):
         return _channelproperty('channel_manager', fn_or_name)
     return lambda fn: _channelproperty(fn_or_name, fn)

--- a/flowz/channels/management.py
+++ b/flowz/channels/management.py
@@ -1,3 +1,4 @@
+import functools
 
 class AbstractChannelAccessor(object):
     channel = None
@@ -49,4 +50,17 @@ class ChannelManager(object):
             return accessor.get()
         except KeyError:
             raise KeyError("No such key %s" % repr(key))
+
+
+def channelproperty(fn):
+    @functools.wraps(fn)
+    def wrapped(self):
+        manager = self.channel_manager
+        name = fn.__name__
+        try:
+            return manager[name]
+        except KeyError:
+            manager.add_builder(name, lambda: fn(self))
+            return manager[name]
+    return property(wrapped)
 

--- a/flowz/channels/management.py
+++ b/flowz/channels/management.py
@@ -1,0 +1,28 @@
+
+class AbstractChannelAccessor(object):
+    channel = None
+
+    def get(self):
+        if self.channel:
+            return self.get_existing()
+        return self.get_new()
+
+
+    def get_existing(self):
+        return self.channel.tee()
+
+
+    def get_new(self):
+        raise NotImplementedError("get_new() needs to be defined.")
+
+
+
+class ChannelAccessor(AbstractChannelAccessor):
+    def __init__(self, buildfunc):
+        self.builder = buildfunc
+
+
+    def get_new(self):
+        self.channel = self.builder()
+        return self.channel
+

--- a/flowz/test/manager_test.py
+++ b/flowz/test/manager_test.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+import itertools
+import mock
+from nose import tools
+
+from flowz.channels import management
+
+def mock_channel():
+    """
+    A mock that supports tee()
+
+    Each successive call to the mock's tee() will give m.tee.callCALL_COUNT where
+    CALL_COUNT is the string version of the current count of the tee call.  That
+    count starts at 0 and increments by 1 per tee call.
+    """
+    m = mock.Mock()
+    m.tee_count = iter(itertools.count(0))
+    m.tee.side_effect = lambda: getattr(m.tee, 'call%d' % next(m.tee_count))
+    return m
+
+
+def test_channel_accessor():
+    # Our channel
+    chan = mock_channel()
+    # Accessor gets a "builder" function that returns the channel.
+    accessor = management.ChannelAccessor(lambda: chan)
+
+    # First call builds and returns the original channel.
+    tools.assert_equal(chan, accessor.get())
+
+    # Second call returns the first tee
+    tools.assert_equal(chan.tee.call0, accessor.get())
+
+    # Third call returns the second tee
+    tools.assert_equal(chan.tee.call1, accessor.get())
+
+    # Fourth call returns the third tee
+    tools.assert_equal(chan.tee.call2, accessor.get())
+
+

--- a/flowz/test/manager_test.py
+++ b/flowz/test/manager_test.py
@@ -93,7 +93,10 @@ class TestChannelProperty(object):
     
     def setup(self):
         self.channel_manager = management.ChannelManager()
-        self.builders = dict(
+        self.builders = self.assemble_builders()
+
+    def assemble_builders(self):
+        return dict(
                 (name, mock.Mock(name='Builder<%s>' % name,
                     return_value=mock_channel('Channel<%s>' %name)))
                 for name in self.BUILDERS)
@@ -161,4 +164,34 @@ class TestChannelProperty(object):
         self.builders['final'].assert_called_once_with(
                 self.chan('child_a').tee.call0,
                 self.chan('child_b').tee.call0)
+
+
+MANAGER_NAME = str(mock.Mock(name='AChannelManager'))
+prop = management.channelproperty(MANAGER_NAME)
+
+class TestChannelPropertyAlternateName(TestChannelProperty):
+    def setup(self):
+        setattr(self, MANAGER_NAME, management.ChannelManager())
+        self.builders = self.assemble_builders()
+
+    @prop
+    def base_a(self):
+        return self.build('base_a')
+
+    @prop
+    def base_b(self):
+        return self.build('base_b')
+
+    @prop
+    def child_a(self):
+        return self.build('child_a', self.base_a)
+
+    @prop
+    def child_b(self):
+        return self.build('child_b', self.base_b)
+
+    @prop
+    def final(self):
+        return self.build('final', self.child_a, self.child_b)
+
 

--- a/flowz/test/manager_test.py
+++ b/flowz/test/manager_test.py
@@ -39,3 +39,52 @@ def test_channel_accessor():
     tools.assert_equal(chan.tee.call2, accessor.get())
 
 
+def test_channel_manager_builders():
+    chan_a, chan_b = mock_channel(), mock_channel()
+    key_a, key_b = mock.Mock(), mock.Mock()
+    # Shows that generative syntax works by passing self along.
+    mgr = management.ChannelManager() \
+            .add_builder(key_a, lambda: chan_a) \
+            .add_builder(key_b, lambda: chan_b)
+
+    # Build/return on first access
+    tools.assert_equal(chan_a, mgr[key_a])
+    # Tee on subsequent access
+    tools.assert_equal(chan_a.tee.call0, mgr[key_a])
+    tools.assert_equal(chan_a.tee.call1, mgr[key_a])
+
+    tools.assert_equal(chan_b, mgr[key_b])
+    tools.assert_equal(chan_b.tee.call0, mgr[key_b])
+    tools.assert_equal(chan_b.tee.call1, mgr[key_b])
+
+
+def test_channel_manager_accessors():
+    access_a, access_b = mock.Mock(), mock.Mock()
+    key_a, key_b = mock.Mock(), mock.Mock()
+
+    # Shows chaining syntax
+    mgr = management.ChannelManager() \
+            .add_accessor(key_a, access_a) \
+            .add_accessor(key_b, access_b)
+
+    # Get access delegates to the accessor's get()
+    tools.assert_equal(access_a.get.return_value, mgr[key_a])
+    tools.assert_equal(access_b.get.return_value, mgr[key_b])
+
+
+def test_channel_manager_channels():
+    chan_a, chan_b = mock_channel(), mock_channel()
+    key_a, key_b = mock.Mock(), mock.Mock()
+
+    mgr = management.ChannelManager() \
+            .add_channel(key_a, chan_a) \
+            .add_channel(key_b, chan_b)
+
+    tools.assert_equal(chan_a, mgr[key_a])
+    tools.assert_equal(chan_b, mgr[key_b])
+    tools.assert_equal(chan_a.tee.call0, mgr[key_a])
+    tools.assert_equal(chan_b.tee.call0, mgr[key_b])
+    tools.assert_equal(chan_a.tee.call1, mgr[key_a])
+    tools.assert_equal(chan_b.tee.call1, mgr[key_b])
+
+


### PR DESCRIPTION
Introduces a small handful of tools that should assist in building channel-based applications.

From a review standpoint, it's probably best to look at the documentation examples within the `flowz.channels.management.channelproperty` decorator docstring, which gives a high-level usage example.  This gives you lazy building of channels, reasonable management of channel tees, and a relatively straightforward syntax for assembling such things.

@PatrickDRusk lemme know what you think.