### PR TITLE
Windowing/grouping channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ A python module for organizing work in terms of asynchronous processing graphs.
 
 _Read the code, buddy._
 
+## Development
+
+For development, we'll give the [git flow strategy](http://nvie.com/posts/a-successful-git-branching-model/) a try.
+
+Do all features on feature branches named appropriately.
+
+The "develop" branch receives new features.
+
+Release branches will get features for assembling a new release.
+
+Release branches will get merged into "master"; "master" should remain in a clean state (tests passing, releaseable).
+

--- a/flowz/artifacts.py
+++ b/flowz/artifacts.py
@@ -214,7 +214,10 @@ class WrappedArtifact(AbstractArtifact):
         return self.value.ensure()
 
     def __getattr__(self, attr):
-        return getattr(self.value, attr)
+        if hasattr(self, 'value'):
+            return getattr(self.value, attr)
+        else:
+            raise AttributeError("No such attribute: %r; value not yet initialized" % attr)
 
     def __getitem__(self, item):
         try:

--- a/flowz/channels/__init__.py
+++ b/flowz/channels/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 from .core import (ChannelDone, Channel, ReadChannel, MapChannel, FlatMapChannel,
                    FilterChannel, FutureChannel, ReadyFutureChannel, TeeChannel,
                    ProducerChannel, IterChannel, ZipChannel, CoGroupChannel,
-                   WindowChannel)
+                   WindowChannel, GroupChannel)

--- a/flowz/channels/__init__.py
+++ b/flowz/channels/__init__.py
@@ -2,4 +2,5 @@ from __future__ import absolute_import
 
 from .core import (ChannelDone, Channel, ReadChannel, MapChannel, FlatMapChannel,
                    FilterChannel, FutureChannel, ReadyFutureChannel, TeeChannel,
-                   ProducerChannel, IterChannel, ZipChannel, CoGroupChannel)
+                   ProducerChannel, IterChannel, ZipChannel, CoGroupChannel,
+                   WindowChannel)

--- a/flowz/channels/core.py
+++ b/flowz/channels/core.py
@@ -442,7 +442,8 @@ class Windower(object):
         mem = self.members
         active = self.keys
 
-        keys = iter(sorted(keys))
+        # Unique keys per item
+        keys = iter(sorted(set(keys)))
         i = 0
 
         try:

--- a/flowz/channels/core.py
+++ b/flowz/channels/core.py
@@ -548,6 +548,23 @@ class WindowChannel(FlatMapChannel):
             raise gen.Return(win.tail())
 
 
+class GroupChannel(WindowChannel):
+    """
+    Group items from an input channel based on keys from a function.
+
+    Like :func:`itertools.groupby` from the standard library, but for channels;
+    also like :class:`WindowChannel`, but the ``transform`` function should
+    return a single hashable key, rather than a sequence of window keys.
+    """
+    def __init__(self, channel, transform):
+        super(GroupChannel, self).__init__(
+                channel, self.wrap_transformer(transform))
+
+    @staticmethod
+    def wrap_transformer(fn):
+        return lambda val: (fn(val),)
+
+
 class FilterChannel(FlatMapChannel):
     """
     Filters a source channel, passing through items that pass a predicate test.

--- a/flowz/channels/core.py
+++ b/flowz/channels/core.py
@@ -282,6 +282,34 @@ class Channel(object):
         return MapChannel(self, lambda item: item[key_or_slice])
 
 
+    def windowby(self, keyfunc):
+        """
+        Window the items according to `keyfunc`.
+
+        Assuming `keyfunc` is a callable that, given as argument
+        any item within `self`, returns a sequence of sortable, hashable
+        keys, applies `keyfunc` to each item and organizes items according
+        to the window keys emitted.
+
+        See the `WindowChannel` for more.
+        """
+        return WindowChannel(self, keyfunc)
+
+
+    def groupby(self, keyfunc):
+        """
+        Group items according to `keyfunc`.
+
+        Assuming `keyfunc` is a calalble that, given as argument any
+        item within `self`, returns grouping key, applies `keyfunc` to
+        each item and organizes items into groups by grouping keys
+        emitted.
+
+        See the `GroupChannel` for more.
+        """
+        return GroupChannel(self, keyfunc)
+
+
 class ReadChannel(Channel):
     """
     Wraps any channel with a read-only interface.

--- a/flowz/test/channels/helpers_test.py
+++ b/flowz/test/channels/helpers_test.py
@@ -13,11 +13,11 @@ class TestChannelHelpers(object):
         return c
 
 
-    def verify_delegation(self, result, mock_cls, *args):
+    def verify_delegation(self, result, mock_cls, *args, **kw):
         # The result is of the proper class
         tools.assert_equal(mock_cls.return_value, result)
         # The class was invoked with expected args.
-        mock_cls.assert_called_once_with(*args)
+        mock_cls.assert_called_once_with(*args, **kw)
 
 
     def test_tee_method(self):
@@ -103,14 +103,27 @@ class TestChannelHelpers(object):
         with mock.patch.object(chn, 'WindowChannel') as wc:
             self.verify_delegation(self.channel.windowby(func),
                     wc,
-                    self.channel, func)
+                    self.channel, transform=func)
+
+
+    def test_windowby_nofunc_method(self):
+        with mock.patch.object(chn, 'WindowChannel') as wc:
+            self.verify_delegation(self.channel.windowby(),
+                    wc,
+                    self.channel, transform=None)
 
     def test_groupby_method(self):
         func = mock.Mock(name='GroupKeyingFunction')
         with mock.patch.object(chn, 'GroupChannel') as gc:
             self.verify_delegation(self.channel.groupby(func),
                     gc,
-                    self.channel, func)
+                    self.channel, transform=func)
+
+    def test_groupby_nofunc_method(self):
+        with mock.patch.object(chn, 'GroupChannel') as gc:
+            self.verify_delegation(self.channel.groupby(),
+                    gc,
+                    self.channel, transform=None)
 
 
 class TestTeeChannelHelpers(TestChannelHelpers):

--- a/flowz/test/channels/helpers_test.py
+++ b/flowz/test/channels/helpers_test.py
@@ -98,6 +98,20 @@ class TestChannelHelpers(object):
             tools.assert_equal(val, func({idx: val}))
 
 
+    def test_windowby_method(self):
+        func = mock.Mock(name='WindowKeyingFunction')
+        with mock.patch.object(chn, 'WindowChannel') as wc:
+            self.verify_delegation(self.channel.windowby(func),
+                    wc,
+                    self.channel, func)
+
+    def test_groupby_method(self):
+        func = mock.Mock(name='GroupKeyingFunction')
+        with mock.patch.object(chn, 'GroupChannel') as gc:
+            self.verify_delegation(self.channel.groupby(func),
+                    gc,
+                    self.channel, func)
+
 
 class TestTeeChannelHelpers(TestChannelHelpers):
     CLASS = chn.TeeChannel
@@ -157,4 +171,12 @@ class TestFlatMapChannelHelpers(TestChannelHelpers):
 
 class TestFilterChannelHelpers(TestMapChannelHelpers):
     CLASS = chn.FilterChannel
+
+
+class TestWindowChannelHelpers(TestMapChannelHelpers):
+    CLASS = chn.WindowChannel
+
+
+class TestGroupChannelHelpers(TestMapChannelHelpers):
+    CLASS = chn.GroupChannel
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     test_suite = 'nose.collector',
     packages = [
         'flowz',
+        'flowz.channels',
         'flowz.examples',
         'flowz.test',
         'flowz.test.channels',


### PR DESCRIPTION
Adds handy dandy new channel types and helper methods for windowing and grouping.

_(Note that this was edited post bugfix)_

```python
from __future__ import print_function
from flowz.channels import core
from flowz import app

def run(*targets):
    app.Flo([t.map(print) for t in targets]).run()

ic = core.IterChannel(range(5))

# Groups by div 3.  The lambda returns the grouping key for an item
by3 = ic.tee().groupby(lambda i: i // 3)

# Windows by div 2 and div 3.  Lambda returns sequence of window keys for an item.
by2and3 = ic.tee().windowby(lambda i: (i // 2, i // 3))

# Should print:
# (0, [0, 1, 2])
# (1, [3, 4])
run(by3)

# Should print:
# (0, [0, 1, 2])
# (1, [2, 3, 4])
# (2, [4])
# (It eliminates duplicate keys per individual value)
run(by2and3)
```