### PR TITLE
Chain channel

### DIFF
--- a/flowz/channels/__init__.py
+++ b/flowz/channels/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 from .core import (ChannelDone, Channel, ReadChannel, MapChannel, FlatMapChannel,
                    FilterChannel, FutureChannel, ReadyFutureChannel, TeeChannel,
                    ProducerChannel, IterChannel, ZipChannel, CoGroupChannel,
-                   WindowChannel, GroupChannel)
+                   WindowChannel, GroupChannel, ChainChannel)

--- a/flowz/channels/core.py
+++ b/flowz/channels/core.py
@@ -911,6 +911,45 @@ class ZipChannel(ReadChannel):
         raise gen.Return(tuple(r))
 
 
+class ChainChannel(ReadChannel):
+    """
+    Chains multiple channels together for iterating in sequence.
+
+    Given N source channels, the ChainChannel acts like a channel-oriented
+    :func:`itertools.chain`, such that:
+
+        yield zc.next() --> chan0.next()
+        yield zc.next() --> chan0.next() # raises ChannelDone! --> chan1.next()
+        yield zc.next() --> chan1.next()
+        yield zc.next() --> chan1.next() # raises ChannelDone! --> chan2.next()
+        ...
+        yield zc.next() --> chanN.next()
+        yield zc.next() --> chanN.next() # raises ChannelDone!
+
+    The ``ChainChannel`` produces ``ChannelDone`` and is considered exhausted
+    one the final channel in its input channels raises ``ChannelDone``.
+    """
+    def __init__(self, channels):
+        # The use of ReadChannel's super is deliberate, as ReadChannel
+        # assumes a single input channel.
+        self.__channels__ = list(channels)
+        super(ReadChannel, self).__init__(self.__reader__)
+
+
+    @gen.coroutine
+    def __next_item__(self):
+        chn = self.__channels__
+        while chn:
+            try:
+                v = yield chn[0].next()
+                raise gen.Return(v)
+            except ChannelDone:
+                chn.pop(0)
+        raise ChannelDone("Channel is done.")
+
+        
+
+
 class CoGroupChannel(ReadChannel):
     """
     Walks all input channels in ascending key order

--- a/flowz/channels/core.py
+++ b/flowz/channels/core.py
@@ -310,6 +310,16 @@ class Channel(object):
         return GroupChannel(self, transform=keyfunc)
 
 
+    def chain(self, *channels):
+        """
+        Chain channels together into a single channel.
+
+        Returns a :class:`ChainChannel` of the original channel chained with
+        any number of given ``channels``.  See :class:`ChainChannel` for more.
+        """
+        return ChainChannel([self] + list(channels))
+
+
 class ReadChannel(Channel):
     """
     Wraps any channel with a read-only interface.

--- a/flowz/test/channels/helpers_test.py
+++ b/flowz/test/channels/helpers_test.py
@@ -125,6 +125,13 @@ class TestChannelHelpers(object):
                     gc,
                     self.channel, transform=None)
 
+    def test_chain_method(self):
+        a, b, c = (mock.Mock(name='Chan%d' % i) for i in range(3))
+        with mock.patch.object(chn, 'ChainChannel') as cc:
+            self.verify_delegation(self.channel.chain(a, b, c),
+                    cc,
+                    [self.channel, a, b, c])
+
 
 class TestTeeChannelHelpers(TestChannelHelpers):
     CLASS = chn.TeeChannel
@@ -192,4 +199,9 @@ class TestWindowChannelHelpers(TestMapChannelHelpers):
 
 class TestGroupChannelHelpers(TestMapChannelHelpers):
     CLASS = chn.GroupChannel
+
+
+class TestChainChannelHelpers(TestZipChannelHelpers):
+    CLASS = chn.ChainChannel
+
 


### PR DESCRIPTION
Adds a ``ChainChannel`` type and associated ``chain`` helper method on all channels.

This is much like ``itertools.chain``, but channel oriented.

This addresses #13.

For instance:

```python
from __future__ import print_function
from flowz.channels import *
from flowz.app import Flo

def ic(length, start=0, step=1):
    return IterChannel(range(start, length + start, step))

Flo([ic(5,1000).chain(ic(5,100), ic(5,10), ic(5)).map(print)]).run()
# 1000
# 1001
# 1002
# 1003
# 1004
# 100
# 101
# 102
# 103
# 104
# 10
# 11
# 12
# 13
# 14
# 0
# 1
# 2
# 3
# 4
```
Any thoughts, @PatrickDRusk ?