### PR TITLE
Channel observer

### DIFF
--- a/flowz/channels/__init__.py
+++ b/flowz/channels/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 from .core import (ChannelDone, Channel, ReadChannel, MapChannel, FlatMapChannel,
                    FilterChannel, FutureChannel, ReadyFutureChannel, TeeChannel,
                    ProducerChannel, IterChannel, ZipChannel, CoGroupChannel,
-                   WindowChannel, GroupChannel)
+                   WindowChannel, GroupChannel, ObserveChannel)

--- a/flowz/channels/core.py
+++ b/flowz/channels/core.py
@@ -310,6 +310,20 @@ class Channel(object):
         return GroupChannel(self, transform=keyfunc)
 
 
+    def observe(self, observer):
+        """
+        Observe items on a channel for side effects
+
+        Given a callable `observer`, passes each message on the channel
+        to `observer` before passing the message along.  Allows observation
+        of channel contents for purposes like logging, metrics, alerting,
+        etc.
+
+        See the `ObserveChannel` for more.
+        """
+        return ObserveChannel(self, observer)
+
+
 class ReadChannel(Channel):
     """
     Wraps any channel with a read-only interface.

--- a/flowz/channels/core.py
+++ b/flowz/channels/core.py
@@ -397,6 +397,31 @@ class MapChannel(ReadChannel):
         raise gen.Return(value)
 
 
+class ObserveChannel(MapChannel):
+    """
+    A channel allowing observation of values on a channel.
+
+    Initialized with a source channel and an observer callable, the callable
+    is applied to each source channel message; the result is discarded and the
+    original message is passed along as the output message.
+
+    This allows for side effects such as logging, metrics calculation,
+    etc.
+    """
+
+    @classmethod
+    def make_observer(cls, callable_):
+        def observer(value):
+            callable_(value)
+            return value
+        return observer
+
+    def __init__(self, channel, observer):
+        super(ObserveChannel, self).__init__(
+                channel,
+                self.make_observer(observer))
+
+
 class FlatMapChannel(MapChannel):
     """
     A channel that allows a per-message transform to 0 or more output messages.

--- a/flowz/test/channels/helpers_test.py
+++ b/flowz/test/channels/helpers_test.py
@@ -125,6 +125,13 @@ class TestChannelHelpers(object):
                     gc,
                     self.channel, transform=None)
 
+    def test_observe_method(self):
+        func = mock.Mock(name='ObserverCallable')
+        with mock.patch.object(chn, 'ObserveChannel') as oc:
+            self.verify_delegation(self.channel.observe(func),
+                    oc,
+                    self.channel, func)
+
 
 class TestTeeChannelHelpers(TestChannelHelpers):
     CLASS = chn.TeeChannel
@@ -192,4 +199,7 @@ class TestWindowChannelHelpers(TestMapChannelHelpers):
 
 class TestGroupChannelHelpers(TestMapChannelHelpers):
     CLASS = chn.GroupChannel
+
+class TestObserveChannelHelpers(TestMapChannelHelpers):
+    CLASS = chn.ObserveChannel
 


### PR DESCRIPTION
See the discussion in #14 for more.  This does that stuff.

Note that I expect a merge conflict versus #13 (whichever gets merged first).  I'll clean that up when it matters.  This is because of the way the imports are laid out in ``flowz.channels``, which we should split out to one import per line.