### PR TITLE
Change to one package per line for channel import

### DIFF
--- a/flowz/channels/__init__.py
+++ b/flowz/channels/__init__.py
@@ -1,6 +1,19 @@
 from __future__ import absolute_import
 
-from .core import (ChannelDone, Channel, ReadChannel, MapChannel, FlatMapChannel,
-                   FilterChannel, FutureChannel, ReadyFutureChannel, TeeChannel,
-                   ProducerChannel, IterChannel, ZipChannel, CoGroupChannel,
-                   WindowChannel, GroupChannel)
+from .core import (
+        Channel,
+        ChannelDone,
+        CoGroupChannel,
+        FilterChannel,
+        FlatMapChannel,
+        FutureChannel,
+        GroupChannel,
+        IterChannel,
+        MapChannel,
+        ProducerChannel,
+        ReadChannel,
+        ReadyFutureChannel,
+        TeeChannel,
+        WindowChannel,
+        ZipChannel)
+


### PR DESCRIPTION
Resolves #19.

While this doesn't switch to the ideal standard of one import, one
line, it makes the import from `flowz.channels.core` into
`flowz.channels` easier to read and less likely to invite conflicts.

Didn't go to "from .core import" per line primarily due to pragmatism,
though that would normally be my preference.