### PR TITLE
Resolves #50 Added support for 2+ channels to channel_inner_join()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 0.7.0
+
+* Adds introspection tools for channel management objects:
+    * `get_channelmethods`
+    * `get_channelproperties`
+* Changes logger names for artifacts and downgrades some messages from INFO level to DEBUG
+    * This change in logger names could break deployed logging configurations, and for this
+      reason, we incremented the minor version; otherwise this would be a micro bump.
+
 # Version 0.6.0
 
 * Adds the `channelmethod` decorator as a callable-oriented version of `channelproperty` (Issue #41)

--- a/flowz/test/util/assembly_test.py
+++ b/flowz/test/util/assembly_test.py
@@ -30,9 +30,16 @@ class AssemblyTest(tt.AsyncTestCase):
     @tt.gen_test
     def test_channel_inner_join(self):
         chan1, chan2 = self.get_two_chans()
-        chan3 = channel_inner_join(chan1, chan2)
-        values = yield drain(chan3)
+        joined = channel_inner_join(chan1, chan2)
+        values = yield drain(joined)
         tools.assert_equal(values, [((2, 2), (2, 1)), ((4, 4), (4, 2))])
+        chan1, chan2 = self.get_two_chans()
+        chan3, chan4 = self.get_two_chans()
+        chan5, chan6 = self.get_two_chans()
+        joined = channel_inner_join(chan1, chan2, chan3, chan4, chan5, chan6)
+        values = yield drain(joined)
+        tools.assert_equal(values, [((2, 2), (2, 1), (2, 2), (2, 1), (2, 2), (2, 1)),
+                                    ((4, 4), (4, 2), (4, 4), (4, 2), (4, 4), (4, 2))])
 
     @tt.gen_test
     def test_incremental_assembly(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'flowz',
-    version = '0.6.0',
+    version = '0.7.0',
     description = 'Async I/O - oriented dependency programming framework',
     url = 'https://github.com/ethanrowe/flowz',
     author = 'Ethan Rowe',


### PR DESCRIPTION
I actually checked to see if there are any existing calls to channel_inner_join() in our code base that rely on the prior "a" and "b" parameters names, and there aren't (as there shouldn't be!).

NOTE: This is currently picking up the changes in...
https://github.com/ethanrowe/flowz/pull/49
...but will stop doing so once that PR is merged.