### PR TITLE
Python 3 and tornado 5 compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,17 @@
 language: python
-python:
-  - "2.7"
-script: python setup.py nosetests
+
+# Test with each combination of python 2.7 and 3.7, and tornado 4.5.3 and 5.1
+matrix:
+  include:
+    - python: 2.7
+      env: TORNADO_VER=4.5.3
+    - python: 2.7
+      env: TORNADO_VER=5.1
+    - python: 3.7
+      env: TORNADO_VER=4.5.3
+    - python: 3.7
+      env: TORNADO_VER=5.1
+
+script:
+- pip install tornado==$TORNADO_VER
+- python setup.py nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
       env: TORNADO_VER=4.5.3
     - python: 2.7
       env: TORNADO_VER=5.1
-    - python: 3.7
+    - python: 3.7-dev
       env: TORNADO_VER=4.5.3
-    - python: 3.7
+    - python: 3.7-dev
       env: TORNADO_VER=5.1
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ matrix:
 
 script:
 - pip install tornado==$TORNADO_VER
+- pip install -e .
 - python setup.py nosetests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.1.0
+
+* Python 3 compatibility fixes
+
 # Version 1.0.0
 
 * `flowz.util.channel_inner_join` takes any number of channels.

--- a/flowz/app.py
+++ b/flowz/app.py
@@ -1,6 +1,7 @@
 import itertools
 import sys
 
+import six
 from tornado import gen
 from tornado import ioloop
 
@@ -10,7 +11,7 @@ class Flo(object):
     """
     Class for managing data processing workflows.
 
-    A `Flo` is given some number of target 
+    A `Flo` is given some number of target
     :class:`flowz.channels.Channel` objects.
 
     The `Flo` can then be `run()`, and it will run a `tornado.ioloop.IOLoop`
@@ -57,8 +58,8 @@ class Flo(object):
         """
         Forces app to stop on unhandled exceptions.
         """
+        result = None
         try:
-            result = None
             if hasattr(target, 'future'):
                 result = yield target.future()
             else:
@@ -89,12 +90,11 @@ class Flo(object):
         self.loop.spawn_callback(self.main)
         self.loop.start()
         if self.exc_info:
-            raise self.exc_info[1], None, self.exc_info[2]
+            six.reraise(self.exc_info[1], None, self.exc_info[2])
 
 
     @gen.coroutine
     def main(self):
-        targets = self.targets
         wrap = self.wrap_target
         while self.targets and getattr(self, 'exc_info') is None:
             yield gen.moment

--- a/flowz/app.py
+++ b/flowz/app.py
@@ -90,7 +90,7 @@ class Flo(object):
         self.loop.spawn_callback(self.main)
         self.loop.start()
         if self.exc_info:
-            six.reraise(self.exc_info[1], None, self.exc_info[2])
+            six.reraise(*self.exc_info)
 
 
     @gen.coroutine

--- a/flowz/artifacts.py
+++ b/flowz/artifacts.py
@@ -218,7 +218,10 @@ class WrappedArtifact(AbstractArtifact):
         return self.value.ensure()
 
     def __getattr__(self, attr):
-        if hasattr(self, 'value'):
+        # NOTE: The text below used to be...
+        # if hasattr(self, 'value'):
+        # ...but that breaks under Python 3, which seems to immediately call __getattr__ again.
+        if 'value' in self.__dict__:
             return getattr(self.value, attr)
         else:
             raise AttributeError("No such attribute: %r; value not yet initialized" % attr)

--- a/flowz/channels/core.py
+++ b/flowz/channels/core.py
@@ -9,6 +9,7 @@ from tornado import ioloop as iol
 from tornado import locks
 
 from flowz import util
+from flowz import compat
 
 
 class ChannelDone(Exception):
@@ -400,14 +401,7 @@ class ReadChannel(Channel):
         except ChannelDone:
             set_channel_done_exception(head, "ReadChannel.__reader__")
         except:
-            # Capture exception information, including traceback
-            exc_info = sys.exc_info()
-            try:
-                # tornado >= 5
-                cc.future_set_exc_info(head, exc_info)
-            except AttributeError:
-                # tornado < 5
-                head.set_exc_info(exc_info)
+            compat.future_set_exc_info(head, sys.exc_info())
 
     @gen.coroutine
     def __next_item__(self):
@@ -508,14 +502,7 @@ class FlatMapChannel(MapChannel):
         except ChannelDone:
             set_channel_done_exception(head, "FlatMapChannel.__reader__")
         except:
-            # Capture exception information, including traceback
-            exc_info = sys.exc_info()
-            try:
-                # tornado >= 5
-                cc.future_set_exc_info(head, exc_info)
-            except AttributeError:
-                # tornado < 5
-                head.set_exc_info(exc_info)
+            compat.future_set_exc_info(head, sys.exc_info())
 
 
 class Windower(object):

--- a/flowz/channels/tools.py
+++ b/flowz/channels/tools.py
@@ -34,7 +34,7 @@ def rolling(window_size):
     return Roller(window_size)
 
 
-def pinned_group_size(lower=0, upper=sys.maxint):
+def pinned_group_size(lower=0, upper=sys.maxsize):
     """
     Returns a function that will test its argument -- expected to be a (k,g) tuple
     with a key and a collection -- and return True iff the length of the collection
@@ -42,7 +42,7 @@ def pinned_group_size(lower=0, upper=sys.maxint):
 
     This is intended to used like `chan.filter(pin_group_size(2, 5))`.
     """
-    return lambda (k, g): lower <= len(g) <= upper
+    return lambda key_group: lower <= len(key_group[1]) <= upper
 
 
 def exact_group_size(size):

--- a/flowz/compat.py
+++ b/flowz/compat.py
@@ -1,0 +1,15 @@
+# Functions assisting with Python 2/3 and Tornado 4/5 compatibility
+
+from tornado import concurrent as cc
+
+
+def future_set_exc_info(fut, exc_info):
+    """
+    Sets the exception information of a `Future`, including the traceback.
+    """
+    try:
+        # tornado >= 5
+        cc.future_set_exc_info(fut, exc_info)
+    except AttributeError:
+        # tornado < 5
+        fut.set_exc_info(exc_info)

--- a/flowz/examples/nested_channel_handling.py
+++ b/flowz/examples/nested_channel_handling.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from tornado import gen
 
 from flowz.app import Flo

--- a/flowz/examples/syntax.py
+++ b/flowz/examples/syntax.py
@@ -22,10 +22,17 @@ odd_triples = triples.tee().flat_map(
 together = doubles.cogroup(triples, even_triples, odd_triples)
 
 # And convert each to a dictionary
-dicts = together.map(lambda (dbls, trpls, eventrp, oddtrp): {
-    'key': dbls[0], 'double': dbls[1], 'triple': trpls[1],
-    'last_even_triple': None if eventrp is None else eventrp[1],
-    'last_odd_triple': None if oddtrp is None else oddtrp[1]})
+def convert_to_dict(chans):
+    (dbls, trpls, eventrp, oddtrp) = chans
+    return {
+        'key': dbls[0],
+        'double': dbls[1],
+        'triple': trpls[1],
+        'last_even_triple': None if eventrp is None else eventrp[1],
+        'last_odd_triple': None if oddtrp is None else oddtrp[1]
+    }
+
+dicts = together.map(convert_to_dict)
 
 # print it and run.
 app.Flo([dicts.map(print)]).run()

--- a/flowz/test/artifacts/artifacts_test.py
+++ b/flowz/test/artifacts/artifacts_test.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 from concurrent import futures
 
+
+import six
 from nose import tools
 from tornado import gen
 from tornado import testing as tt
@@ -17,8 +19,11 @@ class ArtifactsTest(tt.AsyncTestCase):
     NAME = "Fooble"
     NUM_ARR = [1, 2, 3, 4, 5]
     NUM_DICT = {1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}
-    NUM_ORDERED_DICT = OrderedDict([(i, NUM_DICT[i]) for i in NUM_ARR])
-    NUM_REVERSED_DICT = OrderedDict([(i, NUM_DICT[i]) for i in reversed(NUM_ARR)])
+
+    @classmethod
+    def setUpClass(cls):
+        cls.NUM_ORDERED_DICT = OrderedDict([(i, cls.NUM_DICT[i]) for i in cls.NUM_ARR])
+        cls.NUM_REVERSED_DICT = OrderedDict([(i, cls.NUM_DICT[i]) for i in reversed(cls.NUM_ARR)])
 
     # Possible getter/deriver/transform functions
 
@@ -41,7 +46,7 @@ class ArtifactsTest(tt.AsyncTestCase):
 
     @staticmethod
     def derive_key(dict_, value):
-        for (k, v) in dict_.iteritems():
+        for (k, v) in six.iteritems(dict_):
             if v == value:
                 return k
         return None

--- a/flowz/test/channels/read_bound_test.py
+++ b/flowz/test/channels/read_bound_test.py
@@ -21,7 +21,7 @@ class ReadBoundChannelsTest(tt.AsyncTestCase):
         chan = channels.IterChannel(vals)
         chan = channels.MapChannel(chan, lambda i: (i, reads[-1]))
 
-        received = yield drain(chan, lambda (c, l): reads.append(c))
+        received = yield drain(chan, lambda c_l: reads.append(c_l[0]))
 
         tools.assert_equal(expect, received)
 
@@ -39,7 +39,7 @@ class ReadBoundChannelsTest(tt.AsyncTestCase):
         chan = channels.FlatMapChannel(chan,
                 lambda row: ((pair, reads[-1]) for pair in row))
 
-        received = yield drain(chan, lambda (c, l): reads.append(c))
+        received = yield drain(chan, lambda c_l: reads.append(c_l[0]))
 
         tools.assert_equal(expect, received)
 

--- a/flowz/test/util/min_max_test.py
+++ b/flowz/test/util/min_max_test.py
@@ -10,7 +10,7 @@ def min_lt(f):
     @functools.wraps(f)
     def t():
         v = f()
-        print v
+        print(v)
         tools.assert_true(util.MINIMUM < v)
         tools.assert_true(util.MINIMUM <= v)
         tools.assert_true(util.MINIMUM != v)
@@ -24,7 +24,7 @@ def min_eq(f):
     @functools.wraps(f)
     def t():
         v = f()
-        print v
+        print(v)
         tools.assert_true(util.MINIMUM == v)
         tools.assert_true(util.MINIMUM <= v)
         tools.assert_true(util.MINIMUM >= v)
@@ -38,7 +38,7 @@ def max_gt(f):
     @functools.wraps(f)
     def t():
         v = f()
-        print v
+        print(v)
         tools.assert_true(util.MAXIMUM > v)
         tools.assert_true(util.MAXIMUM >= v)
         tools.assert_true(util.MAXIMUM != v)
@@ -52,7 +52,7 @@ def max_eq(f):
     @functools.wraps(f)
     def t():
         v = f()
-        print v
+        print(v)
         tools.assert_true(util.MAXIMUM == v)
         tools.assert_true(util.MAXIMUM >= v)
         tools.assert_true(util.MAXIMUM <= v)

--- a/flowz/util.py
+++ b/flowz/util.py
@@ -8,19 +8,19 @@ class Minimum(object):
     """
     def __gt__(self, other):
         return False
-    
+
     def __lt__(self, other):
         return self is not other
 
     def __eq__(self, other):
         return self is other
-    
+
     def __ne__(self, other):
         return self is not other
-    
+
     def __ge__(self, other):
         return self is other
-    
+
     def __le__(self, other):
         return True
 
@@ -34,16 +34,16 @@ class Maximum(object):
 
     def __lt__(self, other):
         return False
-    
+
     def __eq__(self, other):
         return self is other
-    
+
     def __ne__(self, other):
         return self is not other
-    
+
     def __ge__(self, other):
         return True
-    
+
     def __le__(self, other):
         return self is other
 
@@ -93,7 +93,7 @@ class LastResult(object):
         first = self.determine_first_call(func, first)
         self.next_call = self.build_first_call(first)
         self.trailing_call = self.build_trailing_call(func)
-    
+
     @classmethod
     def determine_first_call(cls, func, firstfunc):
         if firstfunc is None:
@@ -172,7 +172,12 @@ def incremental_assembly(source, dest, assembler):
     # Normal merge.
     out = merge_keyed_channels(source, dest)
 
-    return out.map(LastResult(lambda (k, (v, fn)), last: fn(v, last)))
+    def assemble(k__v_fn, last):
+        # Emulates this Python 2:  lambda (k, (v, fn)), last: fn(v, last)))
+        (k, (v, fn)) = k__v_fn
+        return fn(v, last)
+
+    return out.map(LastResult(assemble))
 
 
 def channel_inner_join(*chans):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'flowz',
-    version = '1.0.0',
+    version = '1.0.0.20180822',
     description = 'Async I/O - oriented dependency programming framework',
     url = 'https://github.com/ethanrowe/flowz',
     author = 'Ethan Rowe',
@@ -21,9 +21,9 @@ setup(
     tests_require = [
         'mock',
         'nose',
-        'six >= 1.9.0',
         ],
     install_requires = [
+        'six >= 1.9.0',
         'tornado >= 4.2',
-        'futures >= 3.0.5'
+        'futures >= 3.0.5;python_version<"3"'
         ])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'flowz',
-    version = '1.0.0.20180824',
+    version = '1.0.0.20180825',
     description = 'Async I/O - oriented dependency programming framework',
     url = 'https://github.com/ethanrowe/flowz',
     author = 'Ethan Rowe',
@@ -24,6 +24,6 @@ setup(
         ],
     install_requires = [
         'six >= 1.9.0',
-        'tornado >= 4.2, < 5',
+        'tornado >= 4.2',
         'futures >= 3.0.5;python_version<"3"'
         ])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'flowz',
-    version = '1.0.0.20180825',
+    version = '1.1.0',
     description = 'Async I/O - oriented dependency programming framework',
     url = 'https://github.com/ethanrowe/flowz',
     author = 'Ethan Rowe',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'flowz',
-    version = '1.0.0.20180822',
+    version = '1.0.0.20180824',
     description = 'Async I/O - oriented dependency programming framework',
     url = 'https://github.com/ethanrowe/flowz',
     author = 'Ethan Rowe',
@@ -24,6 +24,6 @@ setup(
         ],
     install_requires = [
         'six >= 1.9.0',
-        'tornado >= 4.2',
+        'tornado >= 4.2, < 5',
         'futures >= 3.0.5;python_version<"3"'
         ])


### PR DESCRIPTION
The fixes fell along these lines:
1. Dealing with unpacking directly into parameters no longer being allowed (bummer!)
2. Differences in how to re-raise exceptions
3. Difference in how hasattr() works
4. Tornado 5 handles set_exc_info() in a different way
5. Nazi-ish handling of scopes in generators under Python 3.

Item 2 above introduces a dependency on `six` for the pip itself, and not just the tests.

I couldn't figure out a way to handle item 4 that didn't require an ugly try-except block.

There are also some trivial removals of trailing spaces done by my editor, and the removal of a line that had no effects.

I locally tested the four combinations of (python 2.7/python 3.7) X (tornado 4.5.3/tornado 5.1). I didn't tackle doing the same in the .travis.yml, but that might make some sense (or maybe adding tox). Let me know if you'd like me to do that.